### PR TITLE
Wait until Minio is ready before creating buckets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
     env_file: .env
     entrypoint: >
       /bin/sh -c "
+      while ! curl -s --output /dev/null --connect-timeout 1 http://minio:9000; do echo 'Waiting minio...' && sleep 0.1; done;
       /usr/bin/mc alias set minio http://minio:9000 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD;
       /usr/bin/mc mb minio/attachments;
       /usr/bin/mc mb minio/avatars;


### PR DESCRIPTION
## Issue

When the `createbuckets` container is created the `minio` container is ready but minio is not fully initialized.
This result to some or all buckets creation failure.

## Goal

Create a check inside the `createbuckets` container to run buckets creation commands only when the `minio` endpoint is reachable.

## Informations

We use `curl` here because it is provided inside `minio/mc`.