### PR TITLE
NGINX support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 data
 data.old
 .env
+nginx.conf
+nginx/*

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ Then simply go to http://local.revolt.chat:5000
 
 ## Usage
 
-Copy the `.env` file and edit according to your needs.
+Copy the `.env` and `nginx.conf` files and edit according to your needs.
 
 ```bash
 cp .env.example .env
+cp nginx.conf.example nginx.conf
 ```
 
 Then bring up REVOLT:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,3 +84,11 @@ services:
     ports:
       - "7000:3000"
     restart: always
+    
+ # Web port proxy to port 80 (nginx)
+ nginx:
+    image: nginx
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "80:80"

--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -1,0 +1,59 @@
+worker_processes  1;
+#Referes to single threaded process. Generally set to be equal to the number of CPUs or cores.
+
+#error_log  logs/error.log; #error_log  logs/error.log  notice;
+#Specifies the file where server logs.
+
+#pid        logs/nginx.pid;
+#nginx will write its master process ID(PID).
+
+events {
+    worker_connections  1024;
+    # worker_processes and worker_connections allows you to calculate maxclients value:
+    # max_clients = worker_processes * worker_connections
+}
+http {
+server {
+    listen 80;
+    server_name ws.replacemewith.domain;
+    location / {
+      proxy_pass http://127.0.0.1:9000;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+   }
+  upstream ws-backend {
+    # enable sticky session based on IP
+    ip_hash;
+    server 127.0.0.1:9000;
+   }
+server {
+        listen 80;
+        server_name replacemewith.domain;
+        location / {
+        proxy_pass http://127.0.0.1:5000;
+}
+}
+server {
+        listen 80;
+        server_name media.replacemewith.domain;
+        location / {
+        proxy_pass http://127.0.0.1:7000;
+}
+server {
+        listen 80;
+        server_name cdn.replacemewith.domain;
+        location / {
+        proxy_pass http://127.0.0.1:3000;
+}
+}
+
+server {
+        listen 80;
+        server_name api.replacemewith.domain;
+        location / {
+        proxy_pass http://127.0.0.1:8000;
+}
+}
+}


### PR DESCRIPTION
Not entirely sure if its needed to add this but I felt it would be helpful for those that would prefer using port 80 and a custom domain. ( If needed, Could state that `nginx.conf` needs edited where it says to replace if used with domain. (`replacemewith.domain`)