### PR TITLE
env.example: add env vars required to run vortex

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,8 @@ JANUARY_PUBLIC_URL=http://local.revolt.chat:7000
 
 # URL to where Vortex is publicly available
 # VOSO_PUBLIC_URL=https://voso.revolt.chat
+# URL to Vortex websocket
+# VOSO_WS_HOST=wss://voso.revolt.chat
 
 
 ##
@@ -96,4 +98,14 @@ MINIO_ROOT_PASSWORD=minioautumn
 ## Vortex configuration
 ##
 
+# Vortex manage token setting for Delta
 # VOSO_MANAGE_TOKEN=CHANGEME
+# Vortex manage token setting for Vortex itself
+# MANAGE_TOKEN=CHANGEME
+
+# URL where Vortex to listen on
+# WS_URL=wss://voso.revolt.chat
+
+# List of IPs for RTC
+# Note: You'll need to change the placeholder 1.2.3.4 with your real static IP
+# RTC_IPS=0.0.0.0,1.2.3.4


### PR DESCRIPTION
The outcome of my efforts to selfhost vortex.

If I copypasted this correctly, after adding the vortex image to the docker-compose.yml this should lead to a working installation .