### PR TITLE
chore: use warning labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Related issue: https://github.com/revoltchat/delta/issues/116
 
 This repository provides reasonable defaults, so you can immediately get started with it on your local machine.
 
-> ⚠️ Not recommended for production, see below for full guide.
+> **Warning**
+> This is not recommended for production usage - see below for the full guide.
 
 ```bash
 git clone https://github.com/revoltchat/self-hosted revolt
@@ -42,7 +43,7 @@ cd revolt
 
 Copy the `.env` file and edit according to your needs.
 
-> ⚠️ The default configuration is intended for testing and only works on your local machine. If you want to deploy to a remote server, you need to edit the URLs in the `.env` file. \
+> **Warning**: The default configuration is intended for testing and only works on your local machine. If you want to deploy to a remote server, you need to edit the URLs in the `.env` file. \
 > If you get a network error when trying to log in, **double check your configuration before opening an issue.**
 
 ```bash


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects

This modifies the README to use warning labels instead of the ⚠️ emoji. Here's an example:
![CE592F11-B48E-4ED0-B0F1-EA1EEE53D805](https://user-images.githubusercontent.com/42586271/176176040-8e255466-72f9-4e4f-8052-d790540e9063.jpeg)

