### PR TITLE
Added clarification for "hCaptcha API Key"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ JANUARY_PUBLIC_URL=http://local.revolt.chat/january
 # If you are sure that you don't want to use hCaptcha, set to 1.
 REVOLT_UNSAFE_NO_CAPTCHA=1
 
-# hCaptcha API key
+# hCaptcha API key (This is the "Secret key" from your User Settings page)
 # REVOLT_HCAPTCHA_KEY=0x0000000000000000000000000000000000000000
 
 # hCaptcha site key


### PR DESCRIPTION
Added a bit of clarification for the "hCaptcha API Key" section to state that it's actually the "Secret key", not the API Key which is an Enterprise Only feature.

## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
