### PR TITLE
fix: update minio health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,8 +90,8 @@ services:
     env_file: .env
     entrypoint: >
       /bin/sh -c "
-      while ! curl -s --output /dev/null --connect-timeout 1 http://minio:9000; do echo 'Waiting minio...' && sleep 0.1; done;
-      /usr/bin/mc alias set minio http://minio:9000 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD;
+      /usr/bin/mc config host add minio http://minio:9000 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD;
+      while ! /usr/bin/mc ready minio; do echo 'Waiting minio...' && sleep 1; done;
       /usr/bin/mc mb minio/attachments;
       /usr/bin/mc mb minio/avatars;
       /usr/bin/mc mb minio/backgrounds;


### PR DESCRIPTION
- [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [X] I have tested my changes locally and they are working as intended

This PR fixes the `createbuckets` service.
`curl` is not available in the `minio/mc` image anymore, it can be replaced with the `mc ready` command.

Probably fixes https://github.com/revoltchat/self-hosted/issues/76