### PR TITLE
docs: Update "more options here" link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ chmod +x ./generate_config.sh
 ./generate_config.sh your.domain
 ```
 
-You can find [more options here](https://github.com/revoltchat/backend/blob/df074260196f5ed246e6360d8e81ece84d8d9549/crates/core/config/Revolt.toml), some noteworthy configuration options:
+You can find [more options here](https://github.com/revoltchat/backend/blob/main/crates/core/config/Revolt.toml), some noteworthy configuration options:
 
 - Email verification
 - Captcha


### PR DESCRIPTION
The "more options here" link pointed to an old Revolt.toml commit showing options which have since changed. Point to the main branch instead.

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
