### PR TITLE
fix: Use fully qualified image names

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,7 @@ name: revolt
 services:
   # MongoDB: Database
   database:
-    image: mongo
+    image: docker.io/mongo
     restart: always
     volumes:
       - ./data/db:/data/db
@@ -16,12 +16,12 @@ services:
 
   # Redis: Event message broker & KV store
   redis:
-    image: eqalpha/keydb
+    image: docker.io/eqalpha/keydb
     restart: always
 
   # RabbitMQ: Internal message broker
   rabbit:
-    image: rabbitmq:4
+    image: docker.io/rabbitmq:4
     restart: always
     environment:
       RABBITMQ_DEFAULT_USER: rabbituser
@@ -37,7 +37,7 @@ services:
 
   # MinIO: S3-compatible storage server
   minio:
-    image: minio/minio
+    image: docker.io/minio/minio
     command: server /data
     volumes:
       - ./data/minio:/data
@@ -60,7 +60,7 @@ services:
 
   # Caddy: Web server
   caddy:
-    image: caddy
+    image: docker.io/caddy
     restart: always
     env_file: .env.web
     ports:
@@ -162,7 +162,7 @@ services:
 
   # Create buckets for minio.
   createbuckets:
-    image: minio/mc
+    image: docker.io/minio/mc
     depends_on:
       - minio
     entrypoint: >


### PR DESCRIPTION
Use fully qualified names for container images that are hosted on Docker Hub. Some installations, like Podman on a system without changes to the container registry settings, do not default to docker.io.

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
