### PR TITLE
fix: have caddy apply url prefix to relative redirects from services

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,22 +1,30 @@
 {$HOSTNAME} {
 	route /api* {
 		uri strip_prefix /api
-		reverse_proxy http://api:14702
+		reverse_proxy http://api:14702 {
+			header_down Location "^/" "/api/"
+		}
 	}
 
 	route /ws {
 		uri strip_prefix /ws
-		reverse_proxy http://events:14703
+		reverse_proxy http://events:14703 {
+			header_down Location "^/" "/ws/"
+		}
 	}
 
 	route /autumn* {
 		uri strip_prefix /autumn
-		reverse_proxy http://autumn:14704
+		reverse_proxy http://autumn:14704 {
+			header_down Location "^/" "/autumn/"
+		}
 	}
 
 	route /january* {
 		uri strip_prefix /january
-		reverse_proxy http://january:14705
+		reverse_proxy http://january:14705 {
+			header_down Location "^/" "/january/"
+		}
 	}
 
 	reverse_proxy http://web:5000


### PR DESCRIPTION
…g with /

Definitely required for autumn, as /autumn/attachments/:id: will redirect to /attachments/:id:/:filename: But we want the browser to redirect to /autumn/attachments/:id:/:filename:

Speculatively added for the other services

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended

fixes #137 