### PR TITLE
fix: minio/mc deprecated config command, use alias set instead

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -168,7 +168,7 @@ services:
     entrypoint: >
       /bin/sh -c "
       while ! /usr/bin/mc ready minio; do
-        /usr/bin/mc config host add minio http://minio:9000 minioautumn minioautumn;
+        /usr/bin/mc alias set minio http://minio:9000 minioautumn minioautumn;
         echo 'Waiting minio...' && sleep 1;
       done;
       /usr/bin/mc mb minio/revolt-uploads;


### PR DESCRIPTION
Here is the PR where they removed the config command: https://github.com/minio/mc/pull/5201

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
