### PR TITLE
fix(generate_config.sh): tail compatibility

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -17,7 +17,7 @@ echo "" >> Revolt.toml
 echo "[pushd.vapid]" >> Revolt.toml
 openssl ecparam -name prime256v1 -genkey -noout -out vapid_private.pem
 echo "private_key = \"$(base64 -i vapid_private.pem | tr -d '\n' | tr -d '=')\"" >> Revolt.toml
-echo "public_key = \"$(openssl ec -in vapid_private.pem -outform DER|tail -c 65|base64|tr '/+' '_-'|tr -d '\n'|tr -d '=')\"" >> Revolt.toml
+echo "public_key = \"$(openssl ec -in vapid_private.pem -outform DER|tail --bytes 65|base64|tr '/+' '_-'|tr -d '\n'|tr -d '=')\"" >> Revolt.toml
 rm vapid_private.pem
 
 # encryption key for files


### PR DESCRIPTION
Running the generate_config.sh script on Slackware 15 lead to a 
```
tail: cannot open '65' for reading: No such file or directory
``` 
error. This fixes it and should be compatible.

## Please make sure to check the following tasks before opening and submitting a PR

- [ ] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
