### PR TITLE
Replace Hostinger referral link with deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To get started, find yourself a suitable server to deploy onto, we recommend sta
 >
 > **We've partnered with Hostinger to bring you a 20% discount off VPS hosting!**
 >
-> 👉 https://www.hostinger.com/vps-hosting?REFERRALCODE=REVOLTCHAT
+> [![Deploy on Hostinger](https://assets.hostinger.com/vps/deploy.svg)](https://www.hostinger.com/vps/docker-hosting?compose_url=https://raw.githubusercontent.com/revoltchat/self-hosted/refs/heads/master/compose.yml&REFERRALCODE=REVOLTCHAT)
 >
 > We recommend using the _KVM 2_ plan at minimum!\
 > Our testing environment for self-hosted currently sits on a KVM 2 instance, and we are happy to assist with issues.


### PR DESCRIPTION
Using Deploy on Hostinger button will simplify the application deployment. Users will just need to select the plan and application will get deployed automatically.

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
