### PR TITLE
Add a basic GatewayAPI based helm chart

### DIFF
--- a/charts/revolt-helm-gateway-api/Chart.yaml
+++ b/charts/revolt-helm-gateway-api/Chart.yaml
@@ -1,0 +1,7 @@
+name: revolt-helm-gateway-api
+description: A Helm Chart for Revolt with Gateway API
+version: 0.0.1
+apiVersion: v2
+keywords:
+  - revolt
+  - chat

--- a/charts/revolt-helm-gateway-api/README.md
+++ b/charts/revolt-helm-gateway-api/README.md
@@ -1,0 +1,7 @@
+# Revolt helm chart
+
+This is a simple helm chart for revolt.
+
+It assume you have Gateway API, Cert-manager, External-DNS enabled on your Kubernetes cluster.
+
+The values in the values.yaml file should be adapted and substituted by the value generated in the `generate_config.sh` script.

--- a/charts/revolt-helm-gateway-api/templates/api.yaml
+++ b/charts/revolt-helm-gateway-api/templates/api.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    revolt-helm.service: api
+  name: api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      revolt-helm.service: api
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        revolt-helm.service: api
+    spec:
+      containers:
+        - image: ghcr.io/revoltchat/server:{{ .Values.imageTag }}
+          name: api
+          volumeMounts:
+            - mountPath: /Revolt.toml
+              name: api-cm
+              subPath: Revolt.toml
+      restartPolicy: Always
+      volumes:
+        - configMap:
+            items:
+              - key: Revolt.toml
+                path: Revolt.toml
+            name: revolt-cm
+          name: api-cm
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    revolt-helm.service: api
+  name: api
+spec:
+  ports:
+    - name: "14702"
+      port: 14702
+      targetPort: 14702
+  selector:
+    revolt-helm.service: api
+  type: ClusterIP

--- a/charts/revolt-helm-gateway-api/templates/autumn.yaml
+++ b/charts/revolt-helm-gateway-api/templates/autumn.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    revolt-helm.service: autumn
+  name: autumn
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      revolt-helm.service: autumn
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        revolt-helm.service: autumn
+    spec:
+      containers:
+        - image: ghcr.io/revoltchat/autumn:{{ .Values.imageTag }}
+          name: autumn
+          volumeMounts:
+            - mountPath: /Revolt.toml
+              name: autumn-cm
+              subPath: Revolt.toml
+      restartPolicy: Always
+      volumes:
+        - configMap:
+            items:
+              - key: Revolt.toml
+                path: Revolt.toml
+            name: revolt-cm
+          name: autumn-cm
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    revolt-helm.service: autumn
+  name: autumn
+spec:
+  ports:
+    - name: "14704"
+      port: 14704
+      targetPort: 14704
+  selector:
+    revolt-helm.service: autumn
+  type: ClusterIP

--- a/charts/revolt-helm-gateway-api/templates/crond.yaml
+++ b/charts/revolt-helm-gateway-api/templates/crond.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    revolt-helm.service: crond
+  name: crond
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      revolt-helm.service: crond
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        revolt-helm.service: crond
+    spec:
+      containers:
+        - image: ghcr.io/revoltchat/crond:{{ .Values.imageTag }}
+          name: crond
+          volumeMounts:
+            - mountPath: /Revolt.toml
+              name: crond-cm
+              subPath: Revolt.toml
+      restartPolicy: Always
+      volumes:
+        - configMap:
+            items:
+              - key: Revolt.toml
+                path: Revolt.toml
+            name: revolt-cm
+          name: crond-cm

--- a/charts/revolt-helm-gateway-api/templates/events.yaml
+++ b/charts/revolt-helm-gateway-api/templates/events.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    revolt-helm.service: events
+  name: events
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      revolt-helm.service: events
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        revolt-helm.service: events
+    spec:
+      containers:
+        - image: ghcr.io/revoltchat/bonfire:{{ .Values.imageTag }}
+          name: events
+          volumeMounts:
+            - mountPath: /Revolt.toml
+              name: events-cm
+              subPath: Revolt.toml
+      restartPolicy: Always
+      volumes:
+        - configMap:
+            items:
+              - key: Revolt.toml
+                path: Revolt.toml
+            name: revolt-cm
+          name: events-cm
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    revolt-helm.service: events
+  name: events
+spec:
+  ports:
+    - name: "14703"
+      port: 14703
+      targetPort: 14703
+      appProtocol: kubernetes.io/ws
+  selector:
+    revolt-helm.service: events
+  type: ClusterIP

--- a/charts/revolt-helm-gateway-api/templates/january.yaml
+++ b/charts/revolt-helm-gateway-api/templates/january.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    revolt-helm.service: january
+  name: january
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      revolt-helm.service: january
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        revolt-helm.service: january
+    spec:
+      containers:
+        - image: ghcr.io/revoltchat/january:{{ .Values.imageTag }}
+          name: january
+          volumeMounts:
+            - mountPath: /Revolt.toml
+              name: january-cm
+              subPath: Revolt.toml
+      restartPolicy: Always
+      volumes:
+        - configMap:
+            items:
+              - key: Revolt.toml
+                path: Revolt.toml
+            name: revolt-cm
+          name: january-cm
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    revolt-helm.service: january
+  name: january
+spec:
+  ports:
+    - name: "14705"
+      port: 14705
+      targetPort: 14705
+  selector:
+    revolt-helm.service: january
+  type: ClusterIP

--- a/charts/revolt-helm-gateway-api/templates/minio.yaml
+++ b/charts/revolt-helm-gateway-api/templates/minio.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.minio.enabled -}}
+{{- $hostname := .Values.minio.hostname -}}
+{{- $user := .Values.minio.user -}}
+{{- $password := .Values.minio.password -}}
+{{- $domain := .Values.minio.domain -}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    revolt-helm.service: minio
+  name: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      revolt-helm.service: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        revolt-helm.service: minio
+    spec:
+      containers:
+        - args:
+            - server
+            - /data
+          env:
+            - name: MINIO_DOMAIN
+              value: {{ $domain }}
+            - name: MINIO_ROOT_PASSWORD
+              value: {{ $password }}
+            - name: MINIO_ROOT_USER
+              value: {{ $user }}
+          image: docker.io/minio/minio
+          name: minio
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    revolt-helm.service: minio
+  name: minio
+spec:
+  ports:
+    - name: "9000"
+      port: 9000
+      targetPort: 9000
+  selector:
+    revolt-helm.service: minio
+  type: ClusterIP
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: createbuckets
+spec:
+  template:
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - " while ! /usr/bin/mc ready {{ $domain }}; do\n  /usr/bin/mc alias set {{ $domain }} http://{{ $hostname }}:9000 {{ $user }} {{ $password }};\n  echo 'Waiting minio...' && sleep 1;\ndone; /usr/bin/mc mb {{ $domain }}/revolt-uploads; exit 0; "
+          image: docker.io/minio/mc
+          name: createbuckets
+      restartPolicy: OnFailure
+{{- end }}

--- a/charts/revolt-helm-gateway-api/templates/pushd.yaml
+++ b/charts/revolt-helm-gateway-api/templates/pushd.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    revolt-helm.service: pushd
+  name: pushd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      revolt-helm.service: pushd
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        revolt-helm.service: pushd
+    spec:
+      containers:
+        - image: ghcr.io/revoltchat/pushd:{{ .Values.imageTag }}
+          name: pushd
+          volumeMounts:
+            - mountPath: /Revolt.toml
+              name: pushd-cm
+              subPath: Revolt.toml
+      restartPolicy: Always
+      volumes:
+        - configMap:
+            items:
+              - key: Revolt.toml
+                path: Revolt.toml
+            name: revolt-cm
+          name: pushd-cm

--- a/charts/revolt-helm-gateway-api/templates/rabbit.yaml
+++ b/charts/revolt-helm-gateway-api/templates/rabbit.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    revolt-helm.service: rabbit
+  name: rabbit
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      revolt-helm.service: rabbit
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        revolt-helm.service: rabbit
+    spec:
+      containers:
+        - env:
+            - name: RABBITMQ_DEFAULT_PASS
+              value: rabbitpass
+            - name: RABBITMQ_DEFAULT_USER
+              value: rabbituser
+          image: docker.io/rabbitmq:4
+          livenessProbe:
+            exec:
+              command:
+                - rabbitmq-diagnostics -q ping
+            failureThreshold: 3
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 10
+          name: rabbit
+          volumeMounts:
+            - name: rabbit-storage
+              mountPath: /var/lib/rabbitmq
+      restartPolicy: Always
+      volumes:
+        - name: rabbit-storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    revolt-helm.service: rabbit
+  name: rabbit
+spec:
+  ports:
+    - name: "5671"
+      port: 5671
+      targetPort: 5671
+    - name: "5672"
+      port: 5672
+      targetPort: 5672
+  selector:
+    revolt-helm.service: rabbit
+  type: ClusterIP

--- a/charts/revolt-helm-gateway-api/templates/redis.yaml
+++ b/charts/revolt-helm-gateway-api/templates/redis.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    revolt-helm.service: redis
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      revolt-helm.service: redis
+  template:
+    metadata:
+      labels:
+        revolt-helm.service: redis
+    spec:
+      containers:
+        - image: docker.io/eqalpha/keydb
+          name: redis
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    revolt-helm.service: redis
+  name: redis
+spec:
+  ports:
+    - name: "6379"
+      port: 6379
+      targetPort: 6379
+  selector:
+    revolt-helm.service: redis
+  type: ClusterIP

--- a/charts/revolt-helm-gateway-api/templates/revolt-configmap.yaml
+++ b/charts/revolt-helm-gateway-api/templates/revolt-configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    use-subpath: "true"
+  name: revolt-cm
+data:
+  Revolt.toml: |
+    [hosts]
+    app = "https://{{ .Values.externalName }}"
+    api = "https://{{ .Values.externalName }}/api"
+    events = "wss://{{ .Values.externalName }}/ws"
+    autumn = "https://{{ .Values.externalName }}/autumn"
+    january = "https://{{ .Values.externalName }}/january"
+
+    [pushd.vapid]
+    private_key = "{{ .Values.pushdVapid.privateKey }}"
+    public_key = "{{ .Values.pushdVapid.publicKey }}"
+
+    [files]
+    encryption_key = "{{ .Values.files.encryptionKey }}"

--- a/charts/revolt-helm-gateway-api/templates/routing.yaml
+++ b/charts/revolt-helm-gateway-api/templates/routing.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.gatewayAPI.enabled -}}
+{{- $host := .Values.externalName -}}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: revolt-gw
+  {{- with .Values.gatewayAPI.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: cilium
+  listeners:
+  - hostname: {{ $host }}
+    name: revolt-gw-https
+    port: 443
+    protocol: HTTPS
+    tls:
+      certificateRefs:
+      - name: {{ $host | replace "." "-" }}-tls
+        kind: Secret
+{{- range .Values.gatewayAPI.routes }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: revolt-{{ .name }}
+spec:
+  parentRefs:
+    - name: revolt-gw
+  hostnames:
+    - {{ $host }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .path }}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            add:
+              - name: Location
+                value: {{ .path }}
+      backendRefs:
+        - name: {{ .name }}
+          port: {{ .port }}
+{{- end }}
+{{- end }}

--- a/charts/revolt-helm-gateway-api/templates/web.yaml
+++ b/charts/revolt-helm-gateway-api/templates/web.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: v1
+data:
+  HOSTNAME: {{ .Values.externalName }}
+  REVOLT_PUBLIC_URL: https://{{ .Values.externalName }}/api
+kind: ConfigMap
+metadata:
+  labels:
+    revolt-helm.service: web
+  name: web-cm-env
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    revolt-helm.service: web
+  name: web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      revolt-helm.service: web
+  template:
+    metadata:
+      labels:
+        revolt-helm.service: web
+    spec:
+      containers:
+        - envFrom:
+            - configMapRef:
+                name: web-cm-env
+          image: ghcr.io/revoltchat/client:master
+          name: web
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    revolt-helm.service: web
+  name: web
+spec:
+  ports:
+    - name: "5000"
+      port: 5000
+      targetPort: 5000
+  selector:
+    revolt-helm.service: web
+  type: ClusterIP

--- a/charts/revolt-helm-gateway-api/values.yaml
+++ b/charts/revolt-helm-gateway-api/values.yaml
@@ -1,0 +1,38 @@
+---
+externalName: revolt.mylab.net
+pushdVapid:
+  privateKey: "xxx"
+  publicKey: "yyy"
+files:
+  encryptionKey: "zzz"
+
+imageTag: 20250730-1
+
+minio:
+  enabled: true
+  hostname: minio
+  user: minioautumn
+  password: minioautumn
+  domain: minio
+
+gatewayAPI:
+  enabled: true
+  annotations:
+    cert-manager.io/cluster-issuer: mylab.net-letsencrypt
+    external-dns.alpha.kubernetes.io/target: "x,y,z"
+  routes:
+    - path: /api
+      name: api
+      port: 14702
+    - path: /ws
+      name: events
+      port: 14703
+    - path: /autumn
+      name: autumn
+      port: 14704
+    - path: /january
+      name: january
+      port: 14705
+    - path: /
+      name: web
+      port: 5000


### PR DESCRIPTION
Hi,

This is a work in progress for an Helm chart to deploy Revolt in a Kubernetes cluster.

It is really basic and use embedded databases and services, but that can be a start.

To install, create the namespace, modify the values.yaml file to your needs and then install with helm.

It rely on GatewayAPI so should be somewhat agnostic on your implementation (tested with cilium+envoy).

Hope this helps.

## Please make sure to check the following tasks before opening and submitting a PR

- [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [X] I have tested my changes locally and they are working as intended
