### PR TITLE
fix: generate_config.sh appends config, breaking it on 2nd run. Fix #173

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -5,7 +5,7 @@ echo "HOSTNAME=https://$1" > .env.web
 echo "REVOLT_PUBLIC_URL=https://$1/api" >> .env.web
 
 # hostnames
-echo "[hosts]" >> Revolt.toml
+echo "[hosts]" > Revolt.toml
 echo "app = \"https://$1\"" >> Revolt.toml
 echo "api = \"https://$1/api\"" >> Revolt.toml
 echo "events = \"wss://$1/ws\"" >> Revolt.toml


### PR DESCRIPTION
I don't think overwriting the file is a big deal since my understanding is the project doesn't ship with a default config.

I know this seems silly but it has broken the set up of more than 1 user (arguably, our fault for not looking at the config afterwards, but still...)