### PR TITLE
fix: Make config update safer, use local URLs for livekit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@ data*
 .env
 .env.web
 Revolt.toml
+livekit.yml
+Revolt.toml.old
+livekit.yml.old
 
 compose.override.yml

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 if test -f "Revolt.toml"; then
-    echo "Existing config found, running this script will overwrite your existing config. Are you sure you'd like to reconfigure?"
+    echo "Existing config found, running this script will overwrite your existing config and make your previously uploaded files innaccesible. Are you sure you'd like to reconfigure?"
     select yn in "Yes" "No"; do
         case $yn in
             No ) exit;;
-            Yes ) break;;
+            Yes ) mv Revolt.toml Revolt.toml.old && mv livekit.yml livekit.yml.old && break;;
         esac
     done
 fi
@@ -47,7 +47,18 @@ echo "encryption_key = \"$(openssl rand -base64 32)\"" >> Revolt.toml
 livekit_key=$(openssl rand -hex 6)
 livekit_secret=$(openssl rand -hex 24)
 
-# livekit key
+# livekit yml
+echo "rtc:" > livekit.yml
+echo "  use_external_ip: true" >> livekit.yml
+echo "  port_range_start: 50000" >> livekit.yml
+echo "  port_range_end: 50100" >> livekit.yml
+echo "  tcp_port: 7881" >> livekit.yml
+echo "" >> livekit.yml
+echo "redis:" >> livekit.yml
+echo "  address: redis:6379" >> livekit.yml
+echo "" >> livekit.yml
+echo "turn:" >> livekit.yml
+echo "  enabled: false" >> livekit.yml
 echo "" >> livekit.yml
 echo "keys:" >> livekit.yml
 echo "  $livekit_key: $livekit_secret" >> livekit.yml
@@ -55,12 +66,12 @@ echo "" >> livekit.yml
 echo "webhook:" >> livekit.yml
 echo "  api_key: $livekit_key" >> livekit.yml
 echo "  urls:" >> livekit.yml
-echo "  - \"https://$1/ingress/worldwide\"" >> livekit.yml
+echo "  - \"http://voice-ingress:8500/worldwide\"" >> livekit.yml
 
 # livekit config
 echo "" >> Revolt.toml
 echo "[api.livekit.nodes.worldwide]" >> Revolt.toml
-echo "url = \"https://$1/livekit\"" >> Revolt.toml
+echo "url = \"http://livekit:7880\"" >> Revolt.toml
 echo "lat = 0.0" >> Revolt.toml
 echo "lon = 0.0" >> Revolt.toml
 echo "key = \"$livekit_key\"" >> Revolt.toml

--- a/livekit.yml
+++ b/livekit.yml
@@ -1,9 +1,0 @@
-rtc:
-  use_external_ip: true
-  port_range_start: 50000
-  port_range_end: 50100
-  tcp_port: 7881
-redis:
-  address: redis:6379
-turn:
-  enabled: false

--- a/migrations/20260218-voice-config.sh
+++ b/migrations/20260218-voice-config.sh
@@ -30,13 +30,13 @@ echo "" >> livekit.yml
 echo "webhook:" >> livekit.yml
 echo "  api_key: $livekit_key" >> livekit.yml
 echo "  urls:" >> livekit.yml
-echo "  - \"https://$1/ingress/worldwide\"" >> livekit.yml
+echo "  - \"http://voice-ingress:8500/worldwide\"" >> livekit.yml
 
 # Append livekit node configuration to Revolt.toml
 echo "Adding livekit node configuration to Revolt.toml..."
 echo "" >> Revolt.toml
 echo "[api.livekit.nodes.worldwide]" >> Revolt.toml
-echo "url = \"https://$1/livekit\"" >> Revolt.toml
+echo "url = \"http://livekit:7880\"" >> Revolt.toml
 echo "lat = 0.0" >> Revolt.toml
 echo "lon = 0.0" >> Revolt.toml
 echo "key = \"$livekit_key\"" >> Revolt.toml


### PR DESCRIPTION
This change should result in less people losing access to their files on upgrade and fix an issue with some systems not being able to access their livekit due to using external dns instead of docker dns.