### PR TITLE
fix: Make livekit use a bindmount for livekit.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -179,13 +179,18 @@ services:
 
   livekit:
     image: ghcr.io/stoatchat/livekit-server:v1.9.6
+    depends_on:
+      redis:
+        condition: service_started
     command: --config /etc/livekit.yml
-    volumes:
-      - ./livekit.yml:/etc/livekit.yml
     ports:
       - "7881:7881"
       - "50000-50100:50000-50100/udp"
     restart: always
+    volumes:
+      - type: bind
+        source: ./livekit.yml
+        target: /etc/livekit.yml
 
   # Create buckets for minio.
   createbuckets:


### PR DESCRIPTION
A user mentioned in the dev stoat that they had an issue with livekit config not mounting correctly. Switching livekit to use a bind mount like the other containers should fix that issue.

This pr also makes the livekit container require redis as it uses redis.