### PR TITLE
feat: Make the arg order forced and make usage more clear for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Ensure that your secrets in `Revolt.toml` and `secrets.env` match. If your secre
 Run the configuration script with your domain and pass the overwrite flag:
 
 ```bash
-./generate_config.sh your.domain --overwrite
+./generate_config.sh --overwrite your.domain
 ```
 
 Then pull all the latest images:


### PR DESCRIPTION
A user had an issue where their domain was written with `--overwrite`. This change should prevent that from happening and make the usage more clear for the generate_config.sh script.

Closes #251 