### PR TITLE
feat: Enable video, autoconfigure video

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This repository contains configurations and instructions that can be used for de
   - [KeyDB Compatibility](#keydb-compatibility)
   - [Making Your Instance Invite-only](#making-your-instance-invite-only)
   - [Why ports 7881 and 50000-50100/udp aren't in the Caddyfile](#why-ports-7881-and-50000-50100udp-arent-in-the-caddyfile)
+  - [Getting kicked on video enabled instances when turning on video](#getting-kicked-on-video-enabled-instances-when-turning-on-video)
 - [Notices](#notices)
 - [Security Advisories](#security-advisories)
 
@@ -330,6 +331,10 @@ db.invites.insertOne({ _id: "enter_an_invite_code_here" })
 ### Why ports 7881 and 50000-50100/udp aren't in the Caddyfile
 
 Livekit requires ports 7881/tcp and 50000-50100/udp to be openly accessible on the internet. These ports are used for the RTC protocol. Caddy does not support RTC without significant configuration changes that are out of scope of this repo.
+
+### Getting kicked on video enabled instances when turning on video
+
+Due to an incomplete implementation, Stoat will kick any user that attempts to stream a video that is larger than the maximum size defined in `Revolt.toml`. If you would like to increase the maximum size allowed on your Stoat instance, you can do so by modifying the `video_resolution` field under `[features.limits.new_user]` and `[features.limits.default]` to a larger value in your `Revolt.toml`. For example, 4k would be : `[3996, 2160]`.
 
 ## Notices
 

--- a/compose.yml
+++ b/compose.yml
@@ -209,6 +209,6 @@ services:
 
   # Web App
   web:
-    image: ghcr.io/stoatchat/for-web:addb6b7
+    image: ghcr.io/stoatchat/for-web:103d2bf
     restart: always
     env_file: .env.web

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -3,6 +3,7 @@
 SECRETS_FOUND=0
 IS_OVERWRITING=0
 DOMAIN=
+VIDEO_ENABLED=
 
 usage() {
     echo "Usage: ./generate_config.sh [--overwrite] DOMAIN"
@@ -90,6 +91,14 @@ else
     echo "No received. Configuring with built in caddy as primary reverse proxy."
 fi
 
+read -rp "Would you like to enable camera and screen sharing? [Y/n]: "
+if [ "$REPLY" = "n" ] || [ "$REPLY" = "N" ]; then
+    echo "No received. Not configuring video."
+else
+    echo "Yes received. Configuring video."
+    VIDEO_ENABLED=true
+fi
+
 # Generate secrets
 echo "Generating secrets..."
 if [ "$PUSHD_VAPID_PRIVATEKEY" = "" ]; then 
@@ -154,6 +163,7 @@ echo "VITE_API_URL=https://$DOMAIN/api" >> .env.web
 echo "VITE_WS_URL=wss://$DOMAIN/ws" >> .env.web
 echo "VITE_MEDIA_URL=https://$DOMAIN/autumn" >> .env.web
 echo "VITE_PROXY_URL=https://$DOMAIN/january" >> .env.web
+echo "VITE_CFG_ENABLE_VIDEO=$VIDEO_ENABLED" >> .env.web
 
 # hostnames
 echo "[hosts]" > Revolt.toml
@@ -209,6 +219,20 @@ echo "lat = 0.0" >> Revolt.toml
 echo "lon = 0.0" >> Revolt.toml
 echo "key = \"$LIVEKIT_WORLDWIDE_KEY\"" >> Revolt.toml
 echo "secret = \"$LIVEKIT_WORLDWIDE_SECRET\"" >> Revolt.toml
+
+# Video config
+# We need to address issue https://github.com/stoatchat/stoatchat/issues/588 until we adopt a backend version later than 0.12.0
+# We'll enable 1080p video by default, that should be high enough for most users.
+if [[ -n "$VIDEO_ENABLED" ]]; then
+    echo "" >> Revolt.toml
+    echo "[features.limits.new_user]" >> Revolt.toml
+    echo "video_resolution = [1920, 1080]" >> Revolt.toml
+    echo "video_aspect_ratio = [0.3, 10]" >> Revolt.toml
+    echo "" >> Revolt.toml
+    echo "[features.limits.default]" >> Revolt.toml
+    echo "video_resolution = [1920, 1080]" >> Revolt.toml
+    echo "video_aspect_ratio = [0.3, 10]" >> Revolt.toml
+fi
 
 if [[ $IS_OVERWRITING -eq 1 ]]; then
     echo "Overwrote existing config. If any custom configuration was present in old Revolt.toml, you may now copy it over from Revolt.toml.old."


### PR DESCRIPTION
Adds video support, and adds the ability to auto configure video in the `generate_config.sh` script.

Adds a note in the README about Stoat kicking users that try to stream video that is too large

Upgrades the version of the web app used to v0.3.0.

Closes #200 