### PR TITLE
docs(readme): Add warning about breakage on Linux >=6.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ This repository contains configurations and instructions that can be used for de
 > If you are updating an instance from before February 28, 2026, please consult the [notices section](#notices) at the bottom.
 
 > [!WARNING]
-> Due to a broken dependency in mongodb >=8.0, Stoat's database service is currently broken on Linux kernel versions >=6.19.
-> This causes the database container to crash and restart endlessly every 30 seconds or so.
+> Due to a broken dependency in mongodb >=8.0, Stoat's database service is currently broken on Linux kernel versions >=6.19. This causes the database container to crash and restart endlessly every 30 seconds or so.
+> 
 > Until a patch is released, the only option is likely to downgrade your kernel for the time being.
+> 
 > See [the mongodb release notes](https://www.mongodb.com/docs/manual/release-notes/8.0/) for more information.
 
 > [!IMPORTANT]


### PR DESCRIPTION
See https://www.mongodb.com/docs/manual/release-notes/8.0/

It may be that Kernel versions as early as 6.17 may also be affected (see https://github.com/google/tcmalloc/issues/292; possibly even 6.6), but the official mongodb notice references 6.19 as the first broken version, so that's what I went with.

Open to slimming the notice down a little.

I'm on the fence about the utility of the second line of the notice. Rationale behind adding it was that it may help users encountering this issue figure out faster that their issue is related to this breakage, and thus spare at least a few people some of the frustration.