### PR TITLE
feat: Add client config route to Caddy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Revolt.toml.old
 livekit.yml.old
 secrets.env
 secrets.env.old
+stoat.json
 
 compose.override.yml
 compose.override.yml.old

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,14 @@
 {$HOSTNAME} {
+	route /.well-known/stoat.json {
+		uri strip_prefix /.well-known/stoat.json
+		header {
+			Access-Control-Allow-Origin *
+		}
+		file_server {
+			root /data/stoat.json
+		}
+	}
+
 	route /api* {
 		uri strip_prefix /api
 		reverse_proxy http://api:14702 {

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,11 +1,11 @@
 {$HOSTNAME} {
-	route /.well-known/stoat.json {
-		uri strip_prefix /.well-known/stoat.json
+	route /.well-known/stoat {
+		uri strip_prefix /.well-known/stoat
 		header {
 			Access-Control-Allow-Origin *
 		}
 		file_server {
-			root /data/stoat.json
+			root /stoat.json
 		}
 	}
 

--- a/compose.yml
+++ b/compose.yml
@@ -70,6 +70,7 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - ./data/caddy-data:/data
       - ./data/caddy-config:/config
+      - ./stoat.json:/stoat.json
     networks:
       default:
         aliases:

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -e
 SECRETS_FOUND=0
 IS_OVERWRITING=0
 DOMAIN=
@@ -176,6 +177,8 @@ else
     echo "Using old Livekit secrets..."
 fi
 
+GIFBOX="https://api.gifbox.me"
+
 # set hostname for Caddy and vite variables
 echo "HOSTNAME=$STOAT_HOSTNAME" > .env.web
 echo "REVOLT_PUBLIC_URL=https://$DOMAIN/api" >> .env.web
@@ -183,7 +186,12 @@ echo "VITE_API_URL=https://$DOMAIN/api" >> .env.web
 echo "VITE_WS_URL=wss://$DOMAIN/ws" >> .env.web
 echo "VITE_MEDIA_URL=https://$DOMAIN/autumn" >> .env.web
 echo "VITE_PROXY_URL=https://$DOMAIN/january" >> .env.web
+echo "VITE_GIFBOX_URL=$GIFBOX" >> .env.web
 echo "VITE_CFG_ENABLE_VIDEO=$VIDEO_ENABLED" >> .env.web
+
+# client config
+mkdir -p data/caddy-data
+echo "{\"api\":\"https://$DOMAIN/api\",\"gifbox\":\"$GIFBOX\"}" > data/caddy-data/stoat.json
 
 # hostnames
 echo "# All secrets are stored in secrets.env" > Revolt.toml

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -177,8 +177,6 @@ else
     echo "Using old Livekit secrets..."
 fi
 
-GIFBOX="https://api.gifbox.me"
-
 # set hostname for Caddy and vite variables
 echo "HOSTNAME=$STOAT_HOSTNAME" > .env.web
 echo "REVOLT_PUBLIC_URL=https://$DOMAIN/api" >> .env.web
@@ -186,12 +184,11 @@ echo "VITE_API_URL=https://$DOMAIN/api" >> .env.web
 echo "VITE_WS_URL=wss://$DOMAIN/ws" >> .env.web
 echo "VITE_MEDIA_URL=https://$DOMAIN/autumn" >> .env.web
 echo "VITE_PROXY_URL=https://$DOMAIN/january" >> .env.web
-echo "VITE_GIFBOX_URL=$GIFBOX" >> .env.web
 echo "VITE_CFG_ENABLE_VIDEO=$VIDEO_ENABLED" >> .env.web
 
 # client config
 mkdir -p data/caddy-data
-echo "{\"api\":\"https://$DOMAIN/api\",\"gifbox\":\"$GIFBOX\"}" > data/caddy-data/stoat.json
+echo "{\"api\":\"https://$DOMAIN/api\"}" > data/caddy-data/stoat.json
 
 # hostnames
 echo "# All secrets are stored in secrets.env" > Revolt.toml

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -187,8 +187,7 @@ echo "VITE_PROXY_URL=https://$DOMAIN/january" >> .env.web
 echo "VITE_CFG_ENABLE_VIDEO=$VIDEO_ENABLED" >> .env.web
 
 # client config
-mkdir -p data/caddy-data
-echo "{\"api\":\"https://$DOMAIN/api\"}" > data/caddy-data/stoat.json
+echo -n "{\"api\":\"https://$DOMAIN/api\"}" > stoat.json
 
 # hostnames
 echo "# All secrets are stored in secrets.env" > Revolt.toml


### PR DESCRIPTION
Porting this over from https://github.com/stoatchat/for-web/pull/1308 to use Caddy instead so it will work in the field instead of only when Vite is serving. I also added setting the VITE_GIFBOX_URL parameter so that it matches. Currently this cannot be retrieved from the backend API afaik.