### PR TITLE
chore(docs): Update invite creation guide to correct collection name

### DIFF
--- a/Guides.md
+++ b/Guides.md
@@ -148,7 +148,7 @@ docker compose exec database mongosh
 
 # create the invite
 use revolt
-db.invites.insertOne({ _id: "enter_an_invite_code_here" })
+db.account_invites.insertOne({ _id: "enter_an_invite_code_here" })
 ```
 
 ## Enabling the Gif Picker


### PR DESCRIPTION
This one got me walkin in circles for a bit. 
The guide references the wrong collection name. Updated to match.